### PR TITLE
0.2.0: 12th March 2024.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## \[Unreleased\]
 
-## \[0.1.1\] - 2023-12-03
+## \[0.2.0\] - 2024-03-12
+
+### Changed
+
+- Replace StructOpt with Clap.
+- Change repository name from "cat-win-rs" to "wincat-rs".
+- Update the dependencies in Cargo.toml and Cargo.lock.
+- Updated the error handling using `anyhow`.
+- Changes in `README.md` file:
+  - Updated the installation instructions to use `wincat.exe` instead of `cat-win.exe`.
+  - Updated the project name.
+  - Updated the examples to use `wincat.exe` instead of `cat-win.exe`.
+  - Move the support and roadmap section inside the contributing guidelines.
+
+## \[0.1.1\] - 2023-12-??
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "clap"
@@ -110,9 +110,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,181 +3,144 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "cat-win-rs"
-version = "0.1.1"
-dependencies = [
- "anyhow",
- "structopt",
- "winapi",
-]
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "clap_derive"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "libc"
-version = "0.2.150"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "clap_lex"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -187,28 +150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "winapi"
@@ -231,3 +176,78 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincat-rs"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "winapi",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cat-win-rs"
+name = "wincat-rs"
 version = "0.1.1"
 edition = "2021"
 
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 winapi = { version = "0.3", features = ["handleapi", "winbase", "fileapi", "processenv"] }
-structopt = "0.3"
+clap = { version = "4.5.2", features = ["derive"] }
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ targets, hence why I set up the GitHub CI to use Windows.
 ## Usage
 
 ``` console
-.\cat-win.exe <FILEs>
+.\wincat.exe <FILEs>
 ```
+
   - `<FILEs>`: The files whose contents will be concatenated and written to
     stdout.
 
 ## Contributing
 
-Contributions are welcome\!
+Contributions are welcome! Here are the contributing guidelines (I will try to
+keep them as simple as possible):
 
   - Try to use the least amount of `unsafe` blocks. If that's needed make some
     safe wrapper function around it.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,48 @@
-# cat-win
+# wincat-rs
 
 A Windows port of the `cat` coreutils program.
 
-`cat-win` is a command-line utility for Windows that is designed to mimic the functionality of the `cat` command found in Unix-like systems. It allows users to concatenate and display the contents of one or more files to the standard output.
+wincat is designed to mimic the functionality of the `cat` command found in
+Unix-like systems.
 
 ## Installation
 
-No installation is required (except for the Rust compiler). Simply compile the provided Rust code using cargo: `cargo build --release`. If you get an error while compiling on non-Windows OSes, it's because the program uses the `winapi` crate, so it compiles only for Windows, so specify `--target x86_64-pc-windows-gnu` if you're on Unix-like OSes (like macOS, Linux, FreeBSD, ...), like `cargo build --release --target x86_64-pc-windows-gnu`
+No installation is required (except for the Rust compiler). Simply compile the
+provided Rust code using cargo:
+
+``` console
+$ cargo build --release
+```
+
+The code compiles only for Windows targets if you're on Unix-like OSes (i.e.
+macOS, Linux, FreeBSD)
 
 ## Usage
 
-```bash
+``` bash
 .\cat-win.exe <input_files>
 ```
 
-- `<input_files>`: The path to the files whose contents will be displayed. Must be at least one, or else the help page will be printed.
-
-## Examples
-
-```bash
-.\cat-win.exe index.html style.css app.js
-```
-
-```bash
-.\cat-win.exe error.txt
-```
+  - `<input_files>`: The path to the files whose contents will be displayed.
 
 ## Support
 
-For help or issues, please [open an issue](https://github.com/walker84837/cat-win-rs/issues).
+For help or issues, please [open an
+issue](https://github.com/walker84837/wincat-rs/issues).
 
 ## Contributing
 
-Contributions are welcome! Please follow the guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Authors and Acknowledgment
-
-- Sole mantainer - [walker84837](https://github.com/walker84837)
+Contributions are welcome!
 
 ## License
 
-This project is dual-licensed under the MIT or Apache 2.0 License - see the [Apache, Version 2.0](LICENSE_APACHE.md) and [MIT License](LICENSE_MIT.md) files for details.
-
-## Project Status
-
-Development is not very active, so contributions are encouraged.
+This project is dual-licensed under the MIT or Apache 2.0 License - see the
+[Apache, Version 2.0](LICENSE_APACHE.md) and [MIT License](LICENSE_MIT.md) files
+for details.
 
 ## Roadmap
 
-- Feature: Add option for line numbers
-- Enhancement: Add a similar functionality as the `cat` coreutil program (I'm not expecting full similarity as Windows and Unix-based OSes work very differently).
+  - Feature: Add option for line numbers
+  - Enhancement: Add a similar functionality as the `cat` coreutil program (I'm
+    not expecting full similarity as Windows and Unix-based OSes work very
+    differently).

--- a/README.md
+++ b/README.md
@@ -14,35 +14,49 @@ provided Rust code using cargo:
 $ cargo build --release
 ```
 
-The code compiles only for Windows targets if you're on Unix-like OSes (i.e.
-macOS, Linux, FreeBSD)
+As far as I have seen, the code only compiles if you're building for Windows
+targets, hence why I set up the GitHub CI to use Windows.
 
 ## Usage
 
-``` bash
-.\cat-win.exe <input_files>
+``` console
+.\cat-win.exe <FILEs>
 ```
-
-  - `<input_files>`: The path to the files whose contents will be displayed.
-
-## Support
-
-For help or issues, please [open an
-issue](https://github.com/walker84837/wincat-rs/issues).
+  - `<FILEs>`: The files whose contents will be concatenated and written to
+    stdout.
 
 ## Contributing
 
-Contributions are welcome!
+Contributions are welcome\!
+
+  - Try to use the least amount of `unsafe` blocks. If that's needed make some
+    safe wrapper function around it.
+  - I recommend you to use Windows functions (like `winapi` or
+    `std::os::windows`) if performance will be better. However, try to keep a
+    tradeoff between safety and using the Windows API.
+  - Prefer using the standard library over reinventing the wheel.
+  - Format code with
+    ``` console
+    rustfmt --edition 2021
+    ```
+  - If you would like to make big changes (eg. changing libraries for
+    checksums), open an issue, explaining what you'd like to change, the main
+    reasons as to why, and what is the difference between using it or not.
+
+### Roadmap
+
+  - Feature: Add option for line numbers
+  - Enhancement: Add a similar functionality as the `cat` Coreutils program (I'm
+    not expecting full similarity as Windows and Unix-based OSes work very
+    differently).
+
+### Support
+
+For help or issues, please [open an
+issue](https://github.com/walker84837/wincat-rs/issues).
 
 ## License
 
 This project is dual-licensed under the MIT or Apache 2.0 License - see the
 [Apache, Version 2.0](LICENSE_APACHE.md) and [MIT License](LICENSE_MIT.md) files
 for details.
-
-## Roadmap
-
-  - Feature: Add option for line numbers
-  - Enhancement: Add a similar functionality as the `cat` coreutil program (I'm
-    not expecting full similarity as Windows and Unix-based OSes work very
-    differently).

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,6 @@ use std::{
 };
 use winapi::um::{fileapi, handleapi, processenv, winbase};
 
-const HANDLE_FLAG_INHERIT: u32 = 0x00000001;
-
 /// wincat-rs: A Windows port of the `cat` coreutils program.
 #[derive(Parser)]
 struct Args {
@@ -18,6 +16,8 @@ struct Args {
 }
 
 fn main() -> Result<()> {
+    const HANDLE_FLAG_INHERIT: u32 = 0x00000001;
+
     let args = Args::parse();
 
     for file_path in &args.input_files {


### PR DESCRIPTION
- Replace StructOpt with Clap.
- Change repository name from "cat-win-rs" to "wincat-rs".
- Update the dependencies in Cargo.toml and Cargo.lock.
- Updated the error handling using `anyhow`.
- Changes in `README.md` file:
  - Updated the installation instructions to use `wincat.exe` instead of `cat-win.exe`.
  - Updated the project name.
  - Updated the examples to use `wincat.exe` instead of `cat-win.exe`.
  - Move the support and roadmap section inside the contributing guidelines.